### PR TITLE
Add KRIS-TV and WOAI Selena coverage (Mar 31 1995)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1106,6 +1106,11 @@ const EVENTS = [
   // Kurt Cobain — Apr 8 1994 (body found; MTV broke it to Gen X)
   { id:'youtube-OV0Ml3hLGuA',
     title:'MTV News Special — Kurt Cobain Life & Death (Apr 1994)',               year:'1994', decade:1990 },
+  // Selena Quintanilla-Pérez — murdered Mar 31 1995 in Corpus Christi
+  { id:'kris-6-corpus-christi-march-31-1995-selena-killed',
+    title:'KRIS-TV 6 Corpus Christi — Selena Killed (Mar 31 1995)',              year:'1995', decade:1990 },
+  { id:'woai-march-31-1995-selena-killed',
+    title:'WOAI San Antonio — Selena Killed (Mar 31 1995)',                      year:'1995', decade:1990 },
   // Princess Diana — died Aug 31 1997
   { id:'vhsvault_BBC_News_Coverage_of_Princess_Diana_s_Death_9_30pm_31st_August_1997',
     title:'BBC News — Princess Diana Death Coverage (Aug 31 1997)',               year:'1997', decade:1990 },


### PR DESCRIPTION
Two local Texas broadcasts covering the murder of Selena Quintanilla-Pérez, added to the 1990s section of FEATURED_BROADCASTS.

https://claude.ai/code/session_017V7yjtSajznGnF3TFziQHK