### PR TITLE
Remove Pope John Paul II funeral clip from queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1160,8 +1160,6 @@ const EVENTS = [
     title:'NBC News Special Report — Pope John Paul II Dies (Apr 2 2005)',        year:'2005', decade:2000 },
   { id:'pope-john-paul-ii-dies-at-84-abc-world-news-tonight-april-2-2005',
     title:'ABC World News Tonight — Pope John Paul II Dies at 84 (Apr 2 2005)',   year:'2005', decade:2000 },
-  { id:'vhs-47-2005-april-8-popes-funeral-good-morning-america-regis-and-kelly',
-    title:'ABC — Pope John Paul II Funeral Coverage (Apr 8 2005)',                year:'2005', decade:2000 },
   // Michael Jackson — Jun 25 2009 (same day as Farrah Fawcett)
   { id:'abc-news-special-report-june-25-2009',
     title:'ABC News Special Report — Michael Jackson Death (Jun 25 2009)',        year:'2009', decade:2000 },


### PR DESCRIPTION
The funeral (Apr 8 2005) was in EVENTS so it surfaced in the general queue on Apr 2nd alongside the death coverage. Apr 2nd This Day in History should only surface the two clips covering his death.

https://claude.ai/code/session_01GxF9zBPXb6aKthxnd3VAUx