### PR TITLE
Remove broken archive.org links for WPXI and WOAI-TV

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,7 +479,6 @@ const STATIONS = [
 
   // ── SAN ANTONIO ───────────────────────────────────────────────────
   { id:'localnewsarchive_KSAT',     title:'KSAT ABC12 News',          city:'San Antonio, TX',  net:'ABC', decades:[1980,1990,2000] },
-  { id:'localnewsarchive_WOAI-TV',  title:'WOAI NBC4 News',           city:'San Antonio, TX',  net:'NBC', decades:[1980,1990,2000] },
 
   // ── MIAMI / FORT LAUDERDALE ───────────────────────────────────────
   { id:'localnewsarchive_WTVJ',     title:'WTVJ NBC6 News',           city:'Miami, FL',        net:'NBC', decades:[1970,1980,1990] },
@@ -521,7 +520,6 @@ const STATIONS = [
   // ── PITTSBURGH ────────────────────────────────────────────────────
   { id:'localnewsarchive_KDKA-TV',  title:'KDKA CBS2 News',           city:'Pittsburgh, PA',   net:'CBS', decades:[1970,1980,1990,2000] },
   { id:'localnewsarchive_WTAE-TV',  title:'WTAE ABC4 News',           city:'Pittsburgh, PA',   net:'ABC', decades:[1980,1990,2000] },
-  { id:'localnewsarchive_WPXI',     title:'WPXI NBC11 News',          city:'Pittsburgh, PA',   net:'NBC', decades:[1990,2000] },
 
   // ── BALTIMORE ─────────────────────────────────────────────────────
   { id:'localnewsarchive_WMAR-TV',  title:'WMAR ABC2 News',           city:'Baltimore, MD',    net:'ABC', decades:[1980,1990,2000] },


### PR DESCRIPTION
Removes localnewsarchive_WPXI (WPXI NBC11, Pittsburgh) and localnewsarchive_WOAI-TV (WOAI NBC4, San Antonio) from the station library.

https://claude.ai/code/session_01YDyNiYwvQdQobLU5y9Sn7W