### PR TITLE
Add April 16 On This Day entry for Michael Jordan's final NBA game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1336,6 +1336,10 @@ const LOCAL_NEWS = [
   { id:'TheBombingofWestPhilly',
     title:'PBS Frontline — Bombing of West Philly / MOVE 1985',
     market:'Philadelphia', decade:1980 },
+  // Michael Jordan's final NBA game — Apr 16 2003 — 76ers vs. Wizards at First Union Center
+  { id:'wb-17-news-philadelphia-april-16th-2003-joes-video-archives-480p-h-264',
+    title:'WB 17 News Philadelphia — Michael Jordan\'s Final Game (Apr 16 2003)',
+    market:'Philadelphia', decade:2000 },
 
   // ── NATIONAL ARCHIVES / DOCUMENTARY COVERAGE ──────────────────────
   { id:'nbc-news-april-8-1994-kurt-cobain-death',
@@ -1384,6 +1388,8 @@ const THIS_DAY = [
     ids:['wfla-news-channel-8-at-11-weekend-edition-april-7-2001'], starts:[665] },
   { month:4, day:8,  year:1994, headline:'Kurt Cobain, frontman of Nirvana, is found dead at his Seattle home at age 27',
     ids:['kstw-april-8-1994-kurt-cobain-death','nbc-news-april-8-1994-kurt-cobain-death','youtube-OV0Ml3hLGuA'] },
+  { month:4, day:16, year:2003, headline:'Michael Jordan plays the final game of his NBA career as the Philadelphia 76ers defeat his Washington Wizards at the First Union Center',
+    ids:['wb-17-news-philadelphia-april-16th-2003-joes-video-archives-480p-h-264'] },
   { month:4, day:19, year:1995, headline:'A truck bomb destroys the Alfred P. Murrah Federal Building in Oklahoma City, killing 168 people',
     ids:['oklahoma-city-bombing-coverage-april-19-21-1995'] },
   { month:4, day:29, year:1986, headline:'CBS Evening News first reports on the explosion at the Chernobyl nuclear power plant in the USSR',


### PR DESCRIPTION
Adds a THIS_DAY entry for April 16, 2003 marking Michael Jordan's last career game, in which the Philadelphia 76ers defeated his Washington Wizards. Also adds the WB 17 News Philadelphia broadcast to the LOCAL_NEWS library under the Philadelphia market.

https://claude.ai/code/session_01NJ98PVY11BGf9y3wdMZhN3